### PR TITLE
Update for Language Redirect 1.x Compatibility

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -35,8 +35,10 @@ Class extension_backend_language_switcher extends Extension{
 		$LOAD_NUMBER = 955935299;
 		$page = $context['parent']->Page;
 		$author = $context['parent']->Author;
-		$languages = explode(',', Symphony::Configuration()->get('languages', 'language_redirect') );
-		if (sizeof($languages)==0) $languages = explode(',', Symphony::Configuration()->get('language_codes', 'language_redirect') );
+		$codes = Symphony::Configuration()->get('languages', 'language_redirect');
+		if ($codes == '' || $codes == null) $codes = Symphony::Configuration()->get('language_codes', 'language_redirect');
+		$languages = array_map('trim',explode(',', $codes ));
+		
 		$assets_path = URL . '/extensions/backend_language_switcher/assets';
 		
 		// CSS & JS for all admin


### PR DESCRIPTION
Update - made a fix as sizeof returns 1 even if empty - tested on 2.2.5 should be backward compatible with 2.2.x

And now works with Language Redirect 1.0+ as previous worked with beta version. Seeing you're still active around here - mind if eventually I will start preparing for a symphony 2.3 in a dev/integration branch then will send a pull-request once done.
