### PR TITLE
Fix typo

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -11,7 +11,7 @@ Class extension_backend_language_switcher extends Extension{
 		return array(
 			array(
 				'page' => '/backend/',
-				'delegate' => 'InitaliseAdminPageHead',
+				'delegate' => 'InitialiseAdminPageHead',
 				'callback' => 'initializeAdmin',
 			),
 		);


### PR DESCRIPTION
This was originally fixed by Jon Mifsud here: https://github.com/jonmifsud/backend-language-switcher/commit/c63167d1b33fb39471533e0f7bd8e4f45091dc46
